### PR TITLE
feat: add --auto-ignore-localhost-https-errors option

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,53 +151,65 @@ Playwright MCP server supports following arguments. They can be provided in the 
 
 ```
 > npx @playwright/mcp@latest --help
-  --allowed-origins <origins>  semicolon-separated list of origins to allow the
-                               browser to request. Default is to allow all.
-  --blocked-origins <origins>  semicolon-separated list of origins to block the
-                               browser from requesting. Blocklist is evaluated
-                               before allowlist. If used without the allowlist,
-                               requests not matching the blocklist are still
-                               allowed.
-  --block-service-workers      block service workers
-  --browser <browser>          browser or chrome channel to use, possible
-                               values: chrome, firefox, webkit, msedge.
-  --browser-agent <endpoint>   Use browser agent (experimental).
-  --caps <caps>                comma-separated list of capabilities to enable,
-                               possible values: tabs, pdf, history, wait, files,
-                               install. Default is all.
-  --cdp-endpoint <endpoint>    CDP endpoint to connect to.
-  --config <path>              path to the configuration file.
-  --device <device>            device to emulate, for example: "iPhone 15"
-  --executable-path <path>     path to the browser executable.
-  --headless                   run browser in headless mode, headed by default
-  --host <host>                host to bind server to. Default is localhost. Use
-                               0.0.0.0 to bind to all interfaces.
-  --ignore-https-errors        ignore https errors
-  --isolated                   keep the browser profile in memory, do not save
-                               it to disk.
-  --image-responses <mode>     whether to send image responses to the client.
-                               Can be "allow", "omit", or "auto". Defaults to
-                               "auto", which sends images if the client can
-                               display them.
-  --no-sandbox                 disable the sandbox for all process types that
-                               are normally sandboxed.
-  --output-dir <path>          path to the directory for output files.
-  --port <port>                port to listen on for SSE transport.
-  --proxy-bypass <bypass>      comma-separated domains to bypass proxy, for
-                               example ".com,chromium.org,.domain.com"
-  --proxy-server <proxy>       specify proxy server, for example
-                               "http://myproxy:3128" or "socks5://myproxy:8080"
-  --save-trace                 Whether to save the Playwright Trace of the
-                               session into the output directory.
-  --storage-state <path>       path to the storage state file for isolated
-                               sessions.
-  --user-agent <ua string>     specify user agent string
-  --user-data-dir <path>       path to the user data directory. If not
-                               specified, a temporary directory will be created.
-  --viewport-size <size>       specify browser viewport size in pixels, for
-                               example "1280, 720"
-  --vision                     Run server that uses screenshots (Aria snapshots
-                               are used by default)
+  --allowed-origins <origins>           semicolon-separated list of origins to
+                                        allow the browser to request. Default is
+                                        to allow all.
+  --blocked-origins <origins>           semicolon-separated list of origins to
+                                        block the browser from requesting.
+                                        Blocklist is evaluated before allowlist.
+                                        If used without the allowlist, requests
+                                        not matching the blocklist are still
+                                        allowed.
+  --block-service-workers               block service workers
+  --browser <browser>                   browser or chrome channel to use,
+                                        possible values: chrome, firefox,
+                                        webkit, msedge.
+  --browser-agent <endpoint>            Use browser agent (experimental).
+  --caps <caps>                         comma-separated list of capabilities to
+                                        enable, possible values: tabs, pdf,
+                                        history, wait, files, install. Default
+                                        is all.
+  --cdp-endpoint <endpoint>             CDP endpoint to connect to.
+  --config <path>                       path to the configuration file.
+  --device <device>                     device to emulate, for example: "iPhone
+                                        15"
+  --executable-path <path>              path to the browser executable.
+  --headless                            run browser in headless mode, headed by
+                                        default
+  --host <host>                         host to bind server to. Default is
+                                        localhost. Use 0.0.0.0 to bind to all
+                                        interfaces.
+  --ignore-https-errors                 ignore https errors
+  --auto-ignore-localhost-https-errors  automatically ignore https errors for
+                                        localhost URLs
+  --isolated                            keep the browser profile in memory, do
+                                        not save it to disk.
+  --image-responses <mode>              whether to send image responses to the
+                                        client. Can be "allow", "omit", or
+                                        "auto". Defaults to "auto", which sends
+                                        images if the client can display them.
+  --no-sandbox                          disable the sandbox for all process
+                                        types that are normally sandboxed.
+  --output-dir <path>                   path to the directory for output files.
+  --port <port>                         port to listen on for SSE transport.
+  --proxy-bypass <bypass>               comma-separated domains to bypass proxy,
+                                        for example
+                                        ".com,chromium.org,.domain.com"
+  --proxy-server <proxy>                specify proxy server, for example
+                                        "http://myproxy:3128" or
+                                        "socks5://myproxy:8080"
+  --save-trace                          Whether to save the Playwright Trace of
+                                        the session into the output directory.
+  --storage-state <path>                path to the storage state file for
+                                        isolated sessions.
+  --user-agent <ua string>              specify user agent string
+  --user-data-dir <path>                path to the user data directory. If not
+                                        specified, a temporary directory will be
+                                        created.
+  --viewport-size <size>                specify browser viewport size in pixels,
+                                        for example "1280, 720"
+  --vision                              Run server that uses screenshots (Aria
+                                        snapshots are used by default)
 ```
 
 <!--- End of options generated section -->

--- a/src/config.ts
+++ b/src/config.ts
@@ -29,6 +29,10 @@ type Config = PublicConfig & {
    * Run server that is able to connect to the 'Playwright MCP' Chrome extension.
    */
   extension?: boolean;
+  /**
+   * Automatically ignore HTTPS errors for localhost URLs.
+   */
+  autoIgnoreLocalhostHttpsErrors?: boolean;
 };
 
 export type CLIOptions = {
@@ -45,6 +49,7 @@ export type CLIOptions = {
   headless?: boolean;
   host?: string;
   ignoreHttpsErrors?: boolean;
+  autoIgnoreLocalhostHttpsErrors?: boolean;
   isolated?: boolean;
   imageResponses?: 'allow' | 'omit' | 'auto';
   sandbox: boolean;
@@ -185,6 +190,11 @@ export async function configFromCLIOptions(cliOptions: CLIOptions): Promise<Conf
   if (cliOptions.ignoreHttpsErrors)
     contextOptions.ignoreHTTPSErrors = true;
 
+  // When autoIgnoreLocalhostHttpsErrors is enabled, we enable ignoreHTTPSErrors globally
+  // This is because Playwright requires ignoreHTTPSErrors to be set at context creation time
+  if (cliOptions.autoIgnoreLocalhostHttpsErrors)
+    contextOptions.ignoreHTTPSErrors = true;
+
   if (cliOptions.blockServiceWorkers)
     contextOptions.serviceWorkers = 'block';
 
@@ -212,6 +222,7 @@ export async function configFromCLIOptions(cliOptions: CLIOptions): Promise<Conf
     saveTrace: cliOptions.saveTrace,
     outputDir: cliOptions.outputDir,
     imageResponses: cliOptions.imageResponses,
+    autoIgnoreLocalhostHttpsErrors: cliOptions.autoIgnoreLocalhostHttpsErrors,
   };
 
   return result;

--- a/src/program.ts
+++ b/src/program.ts
@@ -40,6 +40,7 @@ program
     .option('--headless', 'run browser in headless mode, headed by default')
     .option('--host <host>', 'host to bind server to. Default is localhost. Use 0.0.0.0 to bind to all interfaces.')
     .option('--ignore-https-errors', 'ignore https errors')
+    .option('--auto-ignore-localhost-https-errors', 'automatically ignore https errors for localhost URLs')
     .option('--isolated', 'keep the browser profile in memory, do not save it to disk.')
     .option('--image-responses <mode>', 'whether to send image responses to the client. Can be "allow", "omit", or "auto". Defaults to "auto", which sends images if the client can display them.')
     .option('--no-sandbox', 'disable the sandbox for all process types that are normally sandboxed.')

--- a/src/tab.ts
+++ b/src/tab.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import debug from 'debug';
 import * as playwright from 'playwright';
 
 import { PageSnapshot } from './pageSnapshot.js';
@@ -72,6 +73,17 @@ export class Tab {
 
   async navigate(url: string) {
     this._clearCollectedArtifacts();
+
+    // Check if we're navigating to localhost with autoIgnoreLocalhostHttpsErrors enabled
+    if (this.context.config.autoIgnoreLocalhostHttpsErrors) {
+      try {
+        const urlObj = new URL(url);
+        if (urlObj.hostname === 'localhost' || urlObj.hostname === '127.0.0.1' || urlObj.hostname === '[::1]')
+          debug('pw:mcp:navigate')(`Navigating to localhost with HTTPS errors ignored due to --auto-ignore-localhost-https-errors flag`);
+      } catch (e) {
+        // Invalid URL, ignore
+      }
+    }
 
     const downloadEvent = callOnPageNoTrace(this.page, page => page.waitForEvent('download').catch(() => {}));
     try {


### PR DESCRIPTION
  This option automatically ignores HTTPS certificate errors for localhost URLs.
  When enabled, the server will ignore HTTPS errors for requests to:
  - localhost
  - 127.0.0.1
  - [::1]

  This is useful for local development with self-signed certificates.